### PR TITLE
override refresh_experiment() in ClusterExperimentManager.py

### DIFF
--- a/simtools/ExperimentManager/ClusterExperimentManager.py
+++ b/simtools/ExperimentManager/ClusterExperimentManager.py
@@ -94,6 +94,10 @@ class ClusterExperimentManager(BaseExperimentManager):
         os.makedirs(experiment_path, exist_ok=True)
         os.makedirs(os.path.join(experiment_path, "Assets"), exist_ok=True)
 
+    def refresh_experiment(self):
+        # Refresh the experiment
+        self.experiment = DataStore.get_experiment(self.experiment.exp_id)    
+
     @staticmethod
     def create_suite(suite_name):
         suite_id = suite_name + '_' + re.sub('[ :.-]', '_', str(datetime.now()))


### PR DESCRIPTION
remove self.check_overseer() in refresh_experiment() to avoid the following error:
![image](https://user-images.githubusercontent.com/19782371/61332647-9f11da80-a7d9-11e9-8ff0-6d4e825b0131.png)

Not sure if this is the correct fix, but it works for me in my local environment with this script: examples\Calibration\example_OptimTool.py